### PR TITLE
/image: Use GS8L for larger images

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -118,24 +118,33 @@ function parsePbmData(pbmData: Buffer, width: number, height: number): Buffer {
   if (width > 512) {
     throw new Error('width must be 512px or less')
   }
-  if (height > 1024) {
-    throw new Error('height must be 1024px or less')
+  if (height > 1600) {
+    throw new Error('height must be 1600px or less')
   }
   const widthBytes = Math.floor((width + 7) / 8)
   const p = widthBytes * height + 10
-  const pLow = p & 0xff
-  const pHigh = p >> 8
+
+  const p1 = p & 0xff
+  const p2 = (p >> 8) & 0xff
+  const p3 = (p >> 16) & 0xff
+  const p4 = p >> 24
+
   const wLow = width & 0xff
   const wHigh = width >> 8
   const hLow = height & 0xff
   const hHigh = height >> 8
+
   return Buffer.from([
     0x1b, 0x40, // initialize printer
-    0x1d, 0x28, 0x4c,
-    pLow, pHigh,
+
+    // use command GS8L to print image
+    // https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lparen_cl_fn112.html
+    0x1d, 0x38, 0x4c,
+    p1, p2, p3, p4,
     0x30, 0x70, 0x30, 0x01, 0x01, 0x31,
     wLow, wHigh, hLow, hHigh,
     ...pbmData,
+
     0x1d, 0x28, 0x4c, 0x02, 0x00, 0x30, 0x32, 0x00, // print what's in the buffer
     0x1b, 0x64, 0x06, // feed 6 lines
     0x1d, 0x56, 0x00, // cut


### PR DESCRIPTION
We were previously using GS(L to print images instead of GS8L (see https://download4.epson.biz/sec_pubs/pos/reference_en/escpos/gs_lparen_cl_fn112.html). The former is the u16 option while the latter is u32; switching to u32 allows us to print larger images.

Note: we still cap the height at 1600px because the Epson TM‐T88V at Recurse seems to only accept commands of up to ~105000 bytes; you can still write larger commands to it, but it won't do anything.

(We found a 512px x 1600px JPEG to be about 105000 bytes).