### PR TITLE
/image: Expose new `cut` query param

### DIFF
--- a/gen/docs/api/index.html
+++ b/gen/docs/api/index.html
@@ -127,6 +127,15 @@
 
   </ul>
 
+  <p><strong>Parameters:</strong></p>
+  <ul>
+
+    <li><code>cut?: number</code> - Provide as a query param
+      Can be 0 or 1; if 1, cut.
+      Default: &quot;1&quot; (cut)</li>
+
+  </ul>
+
 </div>
 
 <div>

--- a/src/image.ts
+++ b/src/image.ts
@@ -137,8 +137,6 @@ function parsePbmData(pbmData: Buffer, width: number, height: number): Buffer {
     wLow, wHigh, hLow, hHigh,
     ...pbmData,
     0x1d, 0x28, 0x4c, 0x02, 0x00, 0x30, 0x32, 0x00, // print what's in the buffer
-    0x1b, 0x64, 0x06, // feed 6 lines
-    0x1d, 0x56, 0x00, // cut
   ])
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -357,6 +357,9 @@ app.post(
  * @type image/bmp
  * @type image/x-ms-bmp
  * @type application/octet-stream
+ * @param {number} cut? Provide as a query param
+ *                       Can be 0 or 1; if 1, cut.
+ *                       Default: "1" (cut)
  */
 app.post('/image',
   express.raw({
@@ -378,14 +381,25 @@ app.post('/image',
       res.status(400).json({error: 'unsupported Content-Type'})
       return
     }
-    let buf: Buffer
+
+    // Parse options from query
+    const cut = req.query.cut !== "0"
+
+    const bufs: Buffer[] = []
     try {
-      buf = await image.generateEscPos(req.body)
+      bufs.push(await image.generateEscPos(req.body))
+
+      if (cut) {
+        bufs.push(new escpos.PrintAndFeedNLines(6).serialize())
+        bufs.push(new escpos.SelectCutModeAndCutPaper(escpos.CutMode.CutPaper, escpos.CutShape.FullCut).serialize())
+      }
     } catch (error) {
       console.error(error)
       res.status(400).json({error: error})
       return
     }
+
+    const buf = Buffer.concat(bufs)
     fs.writeFile(env.outFile, buf, err => {
       if (err) {
         console.error(err)


### PR DESCRIPTION
We move adding the `cut` command to the buffer up from `image.ts` to the `/image` API endpoint. This allows users to choose not to cut after writing the image, which in turn allows users to chain together multiple print commands to print larger images than the printer otherwise allows.